### PR TITLE
(feat) add error handler to react browserify

### DIFF
--- a/client/app/components/FluxHomeApp.react.js
+++ b/client/app/components/FluxHomeApp.react.js
@@ -20,7 +20,7 @@ var FluxHomeApp = React.createClass({
     UserAPI.getUserData();
   },
   componentDidMount: function() {
-    UserStore.addChangeListener(this._onChange);    
+    UserStore.addChangeListener(this._onChange);
   },
   componentWillUnmount: function() {
     UserStore.removeChangeListener(this._onChange);
@@ -38,6 +38,5 @@ var FluxHomeApp = React.createClass({
     this.setState(getProfilesState());
   }
 });
-
 
 module.exports = FluxHomeApp;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,11 +17,12 @@ gulp
   .task('styles', styles)
   .task('watch', watch);
 
-gulp.task('default', ['styles', 'watch', 'browserify', 'serve']);
-gulp.task('build', ['styles', 'browserify', 'serve']);
+gulp.task('default', ['styles', 'browserify', 'watch','serve']);
+gulp.task('build', ['styles', 'browserify']);
 
 var paths = {
   script: './client/app/app.jsx',
+  scripts: ['./client/app/app.jsx','./client/app/**/*.js'],
   styles: './client/styles/*.scss',
   dest: './build'
 };
@@ -36,26 +37,14 @@ function scripts() {
     fullPaths: true
   });
 
-  var watcher = watchify(bundler);
-
-  return watcher
-  .on('update', function() {
-    var updateStart = Date.now();
-    console.log('Updating scripts');
-    watcher.bundle()
-    .pipe(source('bundle.js'))
-
-    //add uglify here
-    .pipe(plumber())
-    .pipe(gulp.dest('./build/'))
-    .pipe(livereload());
-
-    console.log('Updated scripts!', (Date.now() - updateStart)  +'ms');
-  })
-  .bundle()
-  .pipe(source('bundle.js'))
-  .pipe(gulp.dest(paths.dest));
-}
+  bundler.bundle()
+   .on('error', function(err) {
+    console.log('Error with Browserify', err);
+   })
+   .pipe(source('bundle.js'))
+   .pipe(gulp.dest('./build'))
+   .pipe(livereload());
+};
 
 function serve() {
   nodemon({script: 'server.js'});
@@ -78,11 +67,12 @@ function styles() {
             browsers: ['last 2 versions'],
             cascade: false
         }))
-        .pipe(livereload())
-        .pipe(gulp.dest(paths.dest));
+        .pipe(gulp.dest(paths.dest))
+        .pipe(livereload());
 }
 
 function watch() {
   livereload.listen();
   gulp.watch(paths.styles, styles);
+  gulp.watch(paths.scripts, scripts);
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "gulp-livereload": "^3.0.2",
     "gulp-nodemon": "^1.0.4",
     "gulp-plumber": "^0.6.6",
-    "gulp-ruby-sass": "^0.7.1",
     "gulp-sass": "^1.2.4",
     "gulp-sourcemaps": "^1.2.8",
     "mocha": "^2.0.1",


### PR DESCRIPTION
Gulp does not break when there is an error with any of react files.
